### PR TITLE
Retropie hotkeybtn

### DIFF
--- a/mk_arcade_joystick_rpi.c
+++ b/mk_arcade_joystick_rpi.c
@@ -338,14 +338,12 @@ static void mk_close(struct input_dev *dev) {
     mutex_unlock(&mk->mutex);
 }
 
-static int __init mk_setup_pad(struct mk *mk, int idx, int pad_type_arg) {
+static int __init mk_setup_pad(struct mk *mk, int idx, int pad_type) {
     struct mk_pad *pad = &mk->pads[idx];
     struct input_dev *input_dev;
-    int i, pad_type;
+    int i;
     int err;
-    pr_err("pad type : %d\n",pad_type_arg);
-
-    pad_type = pad_type_arg;
+    pr_info("pad type : %d\n", pad_type);
 
     if (pad_type < 1 || pad_type >= MK_MAX) {
         pr_err("Pad type %d unknown\n", pad_type);
@@ -372,13 +370,12 @@ static int __init mk_setup_pad(struct mk *mk, int idx, int pad_type_arg) {
             pr_err("Custom device needs gpio argument\n");
             return -EINVAL;
         } else if(gpio_cfg2.nargs != MK_MAX_BUTTONS){
-             pr_err("Invalid gpio argument\n", pad_type);
+             pr_err("Invalid gpio argument pad_type=%d\n", pad_type);
              return -EINVAL;
         }
     
     }
 
-    pr_err("pad type : %d\n",pad_type);
     pad->dev = input_dev = input_allocate_device();
     if (!input_dev) {
         pr_err("Not enough memory for input device\n");
@@ -442,7 +439,7 @@ static int __init mk_setup_pad(struct mk *mk, int idx, int pad_type_arg) {
     } else {
         setGpioPullUps(getPullUpMask(pad->gpio_maps));
     }
-    printk("GPIO configured for pad%d\n", idx);
+    pr_info("GPIO configured for pad%d\n", idx);
 
     err = input_register_device(pad->dev);
     if (err)

--- a/mk_arcade_joystick_rpi.c
+++ b/mk_arcade_joystick_rpi.c
@@ -61,12 +61,31 @@ MODULE_LICENSE("GPL");
 
 #define BSC1_BASE		(PERI_BASE + 0x804000)
 
+/*
+ * defines for BCM 2711
+ *
+ * refer to "Chapter 5. General Purpose I/O (GPIO)"
+ * in "BCM2711 ARM Peripherals", 2020-02-05
+ */
+#define PUD_2711_MASK		0x3
+#define PUD_2711_REG_OFFSET(p)	((p) / 16)
+#define PUD_2711_REG_SHIFT(p)	(((p) % 16) * 2)
+
+#define BCM2711_PULL_UP		0x1
+
+/* BCM 2711 has a different mechanism for pin pull-up/down/enable  */
+#define GPIO_PUP_PDN_CNTRL_REG0 57      /* Pin pull-up/down for pins 15:0  */
+#define GPIO_PUP_PDN_CNTRL_REG1 58      /* Pin pull-up/down for pins 31:16 */
+#define GPIO_PUP_PDN_CNTRL_REG2 59      /* Pin pull-up/down for pins 47:32 */
+#define GPIO_PUP_PDN_CNTRL_REG3 60      /* Pin pull-up/down for pins 57:48 */
+
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 #define HAVE_TIMER_SETUP
 #endif
 
 static volatile unsigned *gpio;
+static int is_2711;
 
 struct mk_config {
     int args[MK_MAX_DEVICES];
@@ -223,6 +242,22 @@ static int getPullUpMask(int gpioMap[]){
         }
     }
     return mask;
+}
+
+static void set_gpio_pullups_2711(int gpio_map[]) {
+    int i;
+    for (i = 0; i < MK_MAX_BUTTONS; i++) {
+        if (gpio_map[i] != -1) {
+            u32 pud_reg = GPIO_PUP_PDN_CNTRL_REG0
+                          + PUD_2711_REG_OFFSET(gpio_map[i]);
+            u32 shift = PUD_2711_REG_SHIFT(gpio_map[i]);
+            u32 val = *(gpio + pud_reg);
+            val &= ~(PUD_2711_MASK << shift);
+            val |= (BCM2711_PULL_UP << shift);
+            *(gpio + pud_reg) = val;
+        }
+    }
+
 }
 
 static void mk_gpio_read_packet(struct mk_pad * pad, unsigned char *data) {
@@ -401,7 +436,12 @@ static int __init mk_setup_pad(struct mk *mk, int idx, int pad_type_arg) {
         }
     }                
     
-    setGpioPullUps(getPullUpMask(pad->gpio_maps));
+    is_2711 = *(gpio+GPIO_PUP_PDN_CNTRL_REG3) != 0x6770696f;
+    if (is_2711) {
+        set_gpio_pullups_2711(pad->gpio_maps);
+    } else {
+        setGpioPullUps(getPullUpMask(pad->gpio_maps));
+    }
     printk("GPIO configured for pad%d\n", idx);
 
     err = input_register_device(pad->dev);


### PR DESCRIPTION
This PR fixes the pullup configuration for the GPIO pins on the Raspberry Pi 4. 
This change is needed due to the BCM2711 used in the RPi4.

Additionally it cleans up code a little and removes a compiler warning.

Cheers